### PR TITLE
Phase 0 validation harness: IRA recall lighthouse + results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,10 @@ coverage/
 .DS_Store
 Thumbs.db
 
+# Validation datasets and run outputs (large / regenerable)
+validation/data/
+validation/results/
+
 # Purisa specific
 purisa.db
 purisa.db-journal

--- a/backend/purisa/services/coordination.py
+++ b/backend/purisa/services/coordination.py
@@ -165,7 +165,7 @@ class CoordinationAnalyzer:
                 return result
 
             # Detect clusters
-            clusters = self._detect_clusters(graph, hour_start)
+            clusters = self._detect_clusters(graph, hour_start, platform)
 
             # Calculate coordination metrics
             result = self._calculate_metrics(
@@ -487,7 +487,7 @@ class CoordinationAnalyzer:
                 evidence={result.similarity_type: result.evidence}
             )
 
-    def _detect_clusters(self, G: nx.Graph, time_window_start: datetime) -> List[Cluster]:
+    def _detect_clusters(self, G: nx.Graph, time_window_start: datetime, platform: str) -> List[Cluster]:
         """Detect coordination clusters using Louvain community detection."""
         if G.number_of_nodes() < self.config.min_cluster_size:
             return []
@@ -524,9 +524,9 @@ class CoordinationAnalyzer:
 
                 primary_type = max(edge_types, key=edge_types.get) if edge_types else 'unknown'
 
-                # Use time window for cluster_id to ensure uniqueness and reproducibility
+                # Platform + time window: unique across platforms, reproducible across re-runs
                 cluster = Cluster(
-                    cluster_id=f"{time_window_start.strftime('%Y%m%d_%H%M')}_cluster_{i}",
+                    cluster_id=f"{platform}_{time_window_start.strftime('%Y%m%d_%H%M')}_cluster_{i}",
                     members=list(community),
                     density=density,
                     size=len(community),

--- a/validation/README.md
+++ b/validation/README.md
@@ -1,0 +1,122 @@
+# Phase 0 — Validation Harness
+
+Tests the **analytical hypothesis** from `VISION.md`: *structural coordination
+signals reliably separate coordinated from organic collective behaviour.*
+
+The lighthouse test: run the **unchanged** `CoordinationAnalyzer` against the
+public [FiveThirtyEight / Clemson IRA troll-tweet dataset](https://github.com/fivethirtyeight/russian-troll-tweets)
+(~3M tweets from ~2,800 labelled Internet Research Agency accounts, 2012-2018)
+and measure whether it clusters known-coordinated accounts.
+
+## What this measures (and what it can't)
+
+The IRA dataset contains **only** troll accounts — no organic background. On its
+own it measures **recall**: given accounts known to be coordinated, what fraction
+does the engine place in a detected cluster?
+
+It does **not** measure precision or false-positive rate. Those come from the
+other Phase 0 legs (see Roadmap below):
+
+- **Negative controls** — benign-but-busy communities (high volume, high text
+  similarity, zero coordination intent). FPR = fraction of organic accounts flagged.
+- **Synthetic injection** — inject N synthetic coordinated accounts into an
+  organic stream, sweep thresholds, plot ROC.
+
+## Isolation
+
+Validation data never touches `purisa.db`:
+
+- Separate database: `validation/ira.db` (gitignored via the global `*.db` rule)
+- Distinct platform tag: `platform = "ira"` — the analyzer filters by platform,
+  so even a shared DB would not cross-contaminate
+- `source_query = "validation:ira"` on every row
+
+## Usage
+
+```bash
+source backend/venv/bin/activate
+
+# 1. Download the dataset (~600MB, 13 CSVs) into validation/data/
+./validation/download_ira.sh
+
+# 2. Load into validation/ira.db (excludes retweets from analysis by default)
+python3 validation/load_ira.py
+
+# 3. Run the analyzer over a window and compute recall
+python3 validation/run_validation.py --start 2016-10-01T00:00 --end 2016-10-08T00:00
+```
+
+`load_ira.py` prints a posts-per-day density profile at the end — use it to pick
+dense analysis windows (the Oct-Nov 2016 US election stretch is the obvious
+first target). Analyzing all six years hour-by-hour (~50k hours) is pointless;
+most hours are sparse.
+
+For a quick smoke test before committing to the full load:
+
+```bash
+python3 validation/load_ira.py --limit-files 1
+python3 validation/run_validation.py --auto-window
+```
+
+## Retweet handling (important)
+
+A large share of dataset rows are retweets — verbatim copies that the TF-IDF
+similarity detector (>0.8) clusters trivially, which would inflate recall.
+`load_ira.py --retweet-mode` controls this:
+
+| Mode | Behaviour |
+|---|---|
+| `exclude` *(default)* | Loaded with `post_type='retweet'` — stored for stats, **invisible to the analyzer** (it only reads `post_type='post'`). The honest recall number. |
+| `include` | Loaded as `post_type='post'` — analyzer sees them. Use with a distinct `--platform-tag ira_rt` to compare. |
+| `skip` | Not loaded at all. |
+
+Report recall **with and without retweets**; the without-retweets number is the
+one that means anything.
+
+## Metric definitions
+
+- **Account-level recall** = |eligible ∩ clustered| / |eligible|, where
+  *eligible* = troll accounts with ≥K original posts inside the analyzed window
+  (default K=3, matching `min_cluster_size`; reported for K ∈ {1, 3, 5}), and
+  *clustered* = accounts appearing in any detected cluster in that window.
+  The K floor keeps the denominator fair — an account that posted once in the
+  window cannot honestly be counted as a miss.
+- **Per-category recall** — the dataset labels accounts (RightTroll, LeftTroll,
+  NewsFeed, HashtagGamer, NonEnglish, ...). NonEnglish behaviour under the
+  TF-IDF tokenizer is a known question mark; per-category numbers surface it.
+
+## Provenance & ethics notes
+
+- The dataset was compiled by Clemson researchers (Linvill & Warren) from the
+  official IRA handle lists Twitter provided to Congress, and published by
+  FiveThirtyEight explicitly for public research. Validating coordination
+  detectors against it is standard practice in the field.
+- The repo has **no formal license**: use for internal validation is
+  established norm, but **never redistribute the corpus** (hence `data/` is
+  gitignored) or bundle it with Purisa.
+- Treat the labels as **high-precision, unknown-recall** ground truth: every
+  labelled account is a confirmed troll, but unlabelled coordinated accounts
+  existed too. Recall claims are safe; precision claims need synthetic
+  injection, where ground truth is perfect.
+- **Never commit real-account results** to the repo (`results/` is gitignored);
+  pseudonymize handles in anything shared outside the team. Coordination ≠
+  guilt — see VISION.md guardrails.
+
+## Known caveats
+
+- **Timezone**: `publish_date` (`M/D/YYYY H:MM`) has no documented timezone; we
+  assume UTC. This shifts hour buckets uniformly, so sync-window detection
+  (90s) inside an hour is unaffected, but window boundary times are ±hours.
+- **Account creation dates** are not in the dataset — `AccountDB.created_at`
+  stays NULL. Follower/following counts are harvest-time snapshots (max kept).
+- **Rows without a tweet_id** get a deterministic content-hash ID; re-loading is
+  idempotent either way (`INSERT OR IGNORE` on primary key).
+
+## Roadmap (Phase 0 legs)
+
+- [x] IRA loader + recall harness (this scaffold)
+- [ ] Run + calibrate: recall numbers on dense 2016 windows, with/without retweets
+- [ ] Negative control: benign-but-busy organic corpus → false-positive rate
+- [ ] Synthetic injection: threshold sweep → ROC for `sync_window_seconds`,
+      `text_similarity_threshold`, `min_cluster_density`
+- [ ] `REPORT.md` with the three headline metrics: recall, FPR, separation

--- a/validation/README.md
+++ b/validation/README.md
@@ -115,7 +115,7 @@ one that means anything.
 ## Roadmap (Phase 0 legs)
 
 - [x] IRA loader + recall harness (this scaffold)
-- [ ] Run + calibrate: recall numbers on dense 2016 windows, with/without retweets
+- [x] Run + calibrate: recall numbers on dense windows, with/without retweets — see `RESULTS.md`
 - [ ] Negative control: benign-but-busy organic corpus → false-positive rate
 - [ ] Synthetic injection: threshold sweep → ROC for `sync_window_seconds`,
       `text_similarity_threshold`, `min_cluster_density`

--- a/validation/RESULTS.md
+++ b/validation/RESULTS.md
@@ -1,0 +1,71 @@
+# Phase 0 — Run + Calibrate Results (IRA recall)
+
+First full run of the recall harness against the FiveThirtyEight/Clemson IRA
+corpus, 2026-07-08. Unchanged production `CoordinationAnalyzer`, default config
+(90s sync window, TF-IDF >0.8, Louvain min size 3 / density 0.3). Aggregate
+numbers only — per-account results stay in `validation/results/` (gitignored).
+
+## Corpus
+
+2,843 accounts · 1,648,625 original posts · 1,297,582 retweets (loaded as
+`post_type='retweet'`, invisible to the analyzer). Density surprise: the
+densest stretch is **August 2017 (Charlottesville week)**, not the Oct–Nov
+2016 election run — Aug 12–18 2017 all exceed 9,900 analyzer-visible
+posts/day.
+
+## Headline recall (account-level, K = min posts in window)
+
+| Window | Density | K≥1 | K≥3 | K≥5 |
+|---|---|---|---|---|
+| 2017-08-12 → 08-19 (Charlottesville wk) | ~470 posts/hr | 99.6% (234/235) | 99.5% (215/216) | 100% (201/201) |
+| 2016-10-01 → 10-08 (pre-election wk) | ~53 posts/hr | 98.6% (214/217) | 100% (181/181) | 100% (161/161) |
+| 2015-09-16 (median-density day) | ~34 posts/hr | 87.5% (77/88) | 97.4% (37/38) | 100% (27/27) |
+| 2018-01-01 → 01-08 (sparse tail wk) | ~few posts/hr | 60.0% (6/10) | 85.7% (6/7) | 85.7% (6/7) |
+
+With retweets included (`ira_rt` tag): Aug 2017 wk K≥3 = 99.6% (271/272),
+Oct 2016 wk K≥3 = 100% (296/296). **The honest (no-retweet) number matches
+the inflated one** — recall does not depend on verbatim-copy clustering.
+
+Per-category (K≥3, both headline weeks): RightTroll, NewsFeed, HashtagGamer,
+Fearmonger 100%; LeftTroll 80–100% (small n); **NonEnglish 96–100%** — the
+TF-IDF tokenizer question mark from the README resolves benignly, because
+sync/URL/hashtag edges carry non-English accounts even if text similarity
+underperforms.
+
+## Calibration findings
+
+1. **The sync channel saturates.** Median `sync_rate` = 1.0 in *every*
+   analyzed window, even at 53 posts/hr (median gap ~68s < 90s window). On a
+   troll-only corpus at any realistic density, the 90s sync detector alone
+   wires the whole graph — recall here is necessary but cheap. Text
+   similarity flags a median of only ~6% of posts and is doing the real
+   discriminating work. Consequence: **the FPR leg (negative controls) is
+   the load-bearing test**; a busy organic community will also saturate
+   sync_rate, and only the threshold sweep will show whether the composite
+   score separates them.
+2. **Recall degrades where it honestly should.** Misses concentrate in
+   sparse windows among accounts with 1–2 posts (no structural signal
+   exists). K≥3 recall stays ≥97% down to median density; the sparse 2018
+   tail (agency winding down) drops to 85.7% on n=7.
+3. **Coordination scores sit high**: hourly median 85–89 (min 46.7) across
+   both headline weeks — consistent with a corpus that is coordinated by
+   construction.
+
+## Bug found by this run
+
+Cross-platform `cluster_id` collision: IDs were minted from
+`time_window_start` only, while the DB column is globally unique — two
+platforms analyzing the same hour collided and the second platform's
+clusters were **silently dropped** (caught + logged). Surfaced when `ira`
+and `ira_rt` shared `validation/ira.db`; would equally hit bluesky + HN in
+production. Fixed by prefixing the platform
+(`{platform}_{window}_cluster_{i}`); re-analysis cleanup queries by
+platform + window, so no migration needed. Verified: same-day re-run under
+both tags stores cleanly.
+
+## What this does not show
+
+Recall only. Precision / false-positive rate requires the negative-control
+and synthetic-injection legs (see README roadmap). Treat these numbers as
+"the engine does not miss dense coordinated behaviour", not "the engine can
+tell it apart from organic behaviour".

--- a/validation/download_ira.sh
+++ b/validation/download_ira.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Download the FiveThirtyEight/Clemson IRA troll-tweet dataset (~600MB, 13 CSVs)
+# into validation/data/. Skips files that already exist.
+set -euo pipefail
+
+DATA_DIR="$(cd "$(dirname "$0")" && pwd)/data"
+BASE_URL="https://raw.githubusercontent.com/fivethirtyeight/russian-troll-tweets/master"
+
+mkdir -p "$DATA_DIR"
+
+for i in $(seq 1 13); do
+    file="IRAhandle_tweets_${i}.csv"
+    dest="$DATA_DIR/$file"
+    if [[ -s "$dest" ]]; then
+        echo "✓ $file already present, skipping"
+        continue
+    fi
+    echo "↓ $file"
+    curl -fL --retry 3 --progress-bar -o "$dest.partial" "$BASE_URL/$file"
+    mv "$dest.partial" "$dest"
+done
+
+echo "Done. Files in $DATA_DIR:"
+ls -lh "$DATA_DIR"/IRAhandle_tweets_*.csv

--- a/validation/load_ira.py
+++ b/validation/load_ira.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+Load the FiveThirtyEight/Clemson IRA troll-tweet dataset into a validation database.
+
+Reads IRAhandle_tweets_*.csv from validation/data/ and writes AccountDB/PostDB
+rows to validation/ira.db (never purisa.db). Every row is tagged
+platform=<platform-tag> and source_query="validation:ira" so validation data
+is isolated from production data at both the file and the query level.
+
+Retweet handling (see validation/README.md):
+  exclude (default) -> stored with post_type='retweet', invisible to the analyzer
+  include           -> stored as post_type='post', analyzer sees them
+  skip              -> not loaded
+
+Prints a posts-per-day density profile at the end to help pick analysis windows.
+"""
+import hashlib
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+import click
+import pandas as pd
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+# Add backend to path (same pattern as cli.py)
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / 'backend'))
+
+from purisa.database.connection import init_database  # noqa: E402
+from purisa.database.models import AccountDB, PostDB  # noqa: E402
+
+DEFAULT_DB = REPO_ROOT / 'validation' / 'ira.db'
+DEFAULT_DATA_DIR = REPO_ROOT / 'validation' / 'data'
+SOURCE_QUERY = 'validation:ira'
+DATE_FORMAT = '%m/%d/%Y %H:%M'  # e.g. "10/1/2017 22:43" — timezone undocumented, assumed UTC
+
+
+def _is_retweet(row) -> bool:
+    return row.get('retweet') == '1' or row.get('post_type') == 'RETWEET'
+
+
+def _post_id(platform_tag: str, row) -> str:
+    tweet_id = row.get('tweet_id', '')
+    if tweet_id:
+        return f'{platform_tag}:{tweet_id}'
+    # Deterministic fallback for rows without a tweet_id
+    digest = hashlib.sha1(
+        f"{row.get('author', '')}|{row.get('publish_date', '')}|{row.get('content', '')}".encode()
+    ).hexdigest()[:16]
+    return f'{platform_tag}:h:{digest}'
+
+
+def _safe_int(value, default=0) -> int:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return default
+
+
+@click.command()
+@click.option('--data-dir', type=click.Path(path_type=Path), default=DEFAULT_DATA_DIR,
+              help='Directory containing IRAhandle_tweets_*.csv')
+@click.option('--db', 'db_path', type=click.Path(path_type=Path), default=DEFAULT_DB,
+              help='SQLite file for the validation database')
+@click.option('--platform-tag', default='ira',
+              help='Platform value for loaded rows (use e.g. "ira_rt" for a with-retweets variant)')
+@click.option('--retweet-mode', type=click.Choice(['exclude', 'include', 'skip']), default='exclude',
+              help='exclude: load as post_type=retweet (analyzer ignores); include: load as posts; skip: drop')
+@click.option('--limit-files', type=int, default=None, help='Only load the first N CSVs (smoke test)')
+@click.option('--chunk-size', type=int, default=50_000, help='CSV read/insert batch size')
+def main(data_dir: Path, db_path: Path, platform_tag: str, retweet_mode: str,
+         limit_files: int, chunk_size: int):
+    """Load IRA CSVs into the validation database."""
+    csv_files = sorted(data_dir.glob('IRAhandle_tweets_*.csv'))
+    if not csv_files:
+        raise click.ClickException(
+            f'No IRAhandle_tweets_*.csv in {data_dir} — run validation/download_ira.sh first'
+        )
+    if limit_files:
+        csv_files = csv_files[:limit_files]
+
+    db = init_database(f'sqlite:///{db_path}')
+    engine = db.engine
+
+    accounts = {}            # account_id -> column dict (only ~2,800 — kept in memory)
+    hour_density = Counter()  # 'YYYY-MM-DD HH' -> post count (analyzer-visible posts only)
+    stats = Counter()
+
+    for csv_file in csv_files:
+        click.echo(f'Loading {csv_file.name} ...')
+        reader = pd.read_csv(csv_file, dtype=str, keep_default_na=False, chunksize=chunk_size)
+        for chunk in reader:
+            chunk['_created_at'] = pd.to_datetime(
+                chunk['publish_date'], format=DATE_FORMAT, errors='coerce'
+            )
+            post_rows = []
+            for row in chunk.to_dict('records'):
+                created_at = row['_created_at']
+                if pd.isna(created_at):
+                    stats['bad_date'] += 1
+                    continue
+                created_at = created_at.to_pydatetime()
+
+                retweet = _is_retweet(row)
+                if retweet and retweet_mode == 'skip':
+                    stats['retweets_skipped'] += 1
+                    continue
+                post_type = 'retweet' if (retweet and retweet_mode == 'exclude') else 'post'
+
+                author = (row.get('author') or 'unknown').strip().lower()
+                account_id = f'{platform_tag}:{author}'
+
+                acct = accounts.setdefault(account_id, {
+                    'id': account_id,
+                    'username': author,
+                    'platform': platform_tag,
+                    'follower_count': 0,
+                    'following_count': 0,
+                    'post_count': 0,
+                    'platform_metadata': {
+                        'account_category': row.get('account_category', ''),
+                        'account_type': row.get('account_type', ''),
+                        'region': row.get('region', ''),
+                        'dataset': 'fivethirtyeight-ira',
+                    },
+                })
+                acct['follower_count'] = max(acct['follower_count'], _safe_int(row.get('followers')))
+                acct['following_count'] = max(acct['following_count'], _safe_int(row.get('following')))
+                acct['post_count'] = max(acct['post_count'], _safe_int(row.get('updates')))
+
+                post_rows.append({
+                    'id': _post_id(platform_tag, row),
+                    'account_id': account_id,
+                    'platform': platform_tag,
+                    'content': row.get('content', ''),
+                    'created_at': created_at,
+                    'engagement': {},
+                    'platform_metadata': {
+                        'language': row.get('language', ''),
+                        'account_category': row.get('account_category', ''),
+                        'post_type_raw': row.get('post_type', ''),
+                        'retweet': retweet,
+                        'article_url': row.get('article_url', ''),
+                    },
+                    'source_query': SOURCE_QUERY,
+                    'post_type': post_type,
+                })
+                stats['retweets_loaded' if retweet else 'originals_loaded'] += 1
+                if post_type == 'post':
+                    hour_density[created_at.strftime('%Y-%m-%d %H')] += 1
+
+            if post_rows:
+                with engine.begin() as conn:
+                    conn.execute(
+                        sqlite_insert(PostDB.__table__).on_conflict_do_nothing(index_elements=['id']),
+                        post_rows,
+                    )
+        click.echo(f'  running totals: {dict(stats)}')
+
+    if accounts:
+        with engine.begin() as conn:
+            conn.execute(
+                sqlite_insert(AccountDB.__table__).on_conflict_do_nothing(index_elements=['id']),
+                list(accounts.values()),
+            )
+
+    # Density profile — pick analysis windows from this instead of scanning 6 years
+    day_density = Counter()
+    for hour, count in hour_density.items():
+        day_density[hour[:10]] += count
+
+    # Results live next to the DB, so scratch/test runs never touch validation/results/
+    results_dir = db_path.parent / 'results'
+    results_dir.mkdir(exist_ok=True)
+    profile_path = results_dir / f'density_profile_{platform_tag}.json'
+    profile_path.write_text(json.dumps({
+        'platform_tag': platform_tag,
+        'retweet_mode': retweet_mode,
+        'stats': dict(stats),
+        'accounts': len(accounts),
+        'posts_per_hour': dict(sorted(hour_density.items())),
+    }, indent=2))
+
+    click.echo(f'\nLoaded {len(accounts)} accounts | {dict(stats)}')
+    click.echo(f'Density profile written to {profile_path}')
+    click.echo('\nTop 20 densest days (analyzer-visible posts):')
+    for day, count in day_density.most_common(20):
+        click.echo(f'  {day}  {count:>8,} posts')
+
+
+if __name__ == '__main__':
+    main()

--- a/validation/run_validation.py
+++ b/validation/run_validation.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+Run the unchanged CoordinationAnalyzer over a window of IRA validation data
+and compute account-level recall.
+
+Recall = |eligible ∩ clustered| / |eligible|, where eligible = accounts with
+>= K analyzer-visible posts in the window, and clustered = accounts placed in
+any detected cluster. Every account in the IRA dataset is a labelled troll,
+so this is a pure recall measurement (see validation/README.md for what this
+does and does not prove).
+
+The analyzer runs exactly as in production — same config defaults, same code
+path — against the isolated validation database.
+"""
+import json
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import click
+from sqlalchemy import func
+
+# Add backend to path (same pattern as cli.py)
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / 'backend'))
+
+from purisa.database.connection import init_database  # noqa: E402
+from purisa.database.models import AccountDB, PostDB  # noqa: E402
+from purisa.services.coordination import CoordinationAnalyzer  # noqa: E402
+
+DEFAULT_DB = REPO_ROOT / 'validation' / 'ira.db'
+RECALL_K_VALUES = (1, 3, 5)  # min posts in window for an account to count as "eligible"
+
+
+def _auto_window(results_dir: Path, platform_tag: str) -> tuple[datetime, datetime]:
+    """Pick the densest single day from the loader's density profile."""
+    profile_path = results_dir / f'density_profile_{platform_tag}.json'
+    if not profile_path.exists():
+        raise click.ClickException(
+            f'{profile_path} not found — run load_ira.py first, or pass --start/--end'
+        )
+    profile = json.loads(profile_path.read_text())
+    days = Counter()
+    for hour, count in profile['posts_per_hour'].items():
+        days[hour[:10]] += count
+    if not days:
+        raise click.ClickException('Density profile is empty — did the load succeed?')
+    densest_day, count = days.most_common(1)[0]
+    click.echo(f'Auto-window: densest day is {densest_day} ({count:,} posts)')
+    start = datetime.fromisoformat(densest_day)
+    return start, start + timedelta(days=1)
+
+
+@click.command()
+@click.option('--db', 'db_path', type=click.Path(path_type=Path), default=DEFAULT_DB,
+              help='Validation SQLite database')
+@click.option('--platform-tag', default='ira', help='Platform value used at load time')
+@click.option('--start', type=click.DateTime(formats=['%Y-%m-%d', '%Y-%m-%dT%H:%M', '%Y-%m-%dT%H:%M:%S']),
+              default=None, help='Window start (ISO, e.g. 2016-10-01T00:00)')
+@click.option('--end', type=click.DateTime(formats=['%Y-%m-%d', '%Y-%m-%dT%H:%M', '%Y-%m-%dT%H:%M:%S']),
+              default=None, help='Window end (ISO, exclusive)')
+@click.option('--auto-window', is_flag=True, help='Analyze the densest day from the density profile')
+@click.option('--output', type=click.Path(path_type=Path), default=None,
+              help='Metrics JSON path (default: validation/results/metrics_<tag>_<start>.json)')
+def main(db_path: Path, platform_tag: str, start: datetime, end: datetime,
+         auto_window: bool, output: Path):
+    """Analyze a window of validation data and report recall."""
+    results_dir = db_path.parent / 'results'
+    if auto_window:
+        start, end = _auto_window(results_dir, platform_tag)
+    if not start or not end:
+        raise click.ClickException('Pass --start and --end, or --auto-window')
+    if not db_path.exists():
+        raise click.ClickException(f'{db_path} not found — run load_ira.py first')
+
+    db = init_database(f'sqlite:///{db_path}')
+
+    click.echo(f'Analyzing {platform_tag} from {start} to {end} '
+               f'({int((end - start).total_seconds() // 3600)} hourly windows)')
+    analyzer = CoordinationAnalyzer()
+    results = analyzer.analyze_range(platform_tag, start, end)
+
+    # --- Recall ---------------------------------------------------------
+    with db.get_session() as session:
+        post_counts = dict(
+            session.query(PostDB.account_id, func.count(PostDB.id))
+            .filter(
+                PostDB.platform == platform_tag,
+                PostDB.created_at >= start,
+                PostDB.created_at < end,
+                PostDB.post_type == 'post',
+            )
+            .group_by(PostDB.account_id)
+            .all()
+        )
+        category_by_account = {
+            acct.id: (acct.platform_metadata or {}).get('account_category', 'Unknown')
+            for acct in session.query(AccountDB).filter(AccountDB.platform == platform_tag).all()
+        }
+
+    clustered = set()
+    for result in results:
+        for cluster in result.clusters:
+            clustered.update(cluster.members)
+
+    recall_by_k = {}
+    for k in RECALL_K_VALUES:
+        eligible = {a for a, n in post_counts.items() if n >= k}
+        hits = eligible & clustered
+        recall_by_k[k] = {
+            'eligible': len(eligible),
+            'clustered': len(hits),
+            'recall': round(len(hits) / len(eligible), 4) if eligible else None,
+        }
+
+    by_category = defaultdict(lambda: {'eligible': 0, 'clustered': 0})
+    k_default = 3
+    for account_id, n in post_counts.items():
+        if n < k_default:
+            continue
+        cat = category_by_account.get(account_id, 'Unknown')
+        by_category[cat]['eligible'] += 1
+        if account_id in clustered:
+            by_category[cat]['clustered'] += 1
+    for cat, row in by_category.items():
+        row['recall'] = round(row['clustered'] / row['eligible'], 4) if row['eligible'] else None
+
+    hourly = [{
+        'hour': r.time_window_start.isoformat(),
+        'posts': r.total_posts,
+        'coordinated_posts': r.coordinated_posts,
+        'clusters': len(r.clusters),
+        'coordination_score': round(r.coordination_score, 2),
+        'sync_rate': round(r.sync_rate, 4),
+        'text_similarity_rate': round(r.text_similarity_rate, 4),
+    } for r in results]
+
+    metrics = {
+        'generated_for': {
+            'platform_tag': platform_tag,
+            'db': str(db_path),
+            'window': {'start': start.isoformat(), 'end': end.isoformat()},
+            'analyzer_config': vars(analyzer.config),
+        },
+        'recall_by_min_posts': recall_by_k,
+        'recall_by_category_k3': dict(by_category),
+        'totals': {
+            'active_accounts': len(post_counts),
+            'clustered_accounts': len(clustered),
+            'posts_analyzed': sum(r.total_posts for r in results),
+            'clusters_detected': sum(len(r.clusters) for r in results),
+        },
+        'hourly': hourly,
+    }
+
+    results_dir.mkdir(exist_ok=True)
+    if output is None:
+        output = results_dir / f'metrics_{platform_tag}_{start.strftime("%Y%m%dT%H%M")}.json'
+    output.write_text(json.dumps(metrics, indent=2))
+
+    # --- Report ---------------------------------------------------------
+    click.echo(f'\n=== Recall ({platform_tag}, {start} → {end}) ===')
+    for k, row in recall_by_k.items():
+        recall = f"{row['recall']:.1%}" if row['recall'] is not None else 'n/a'
+        click.echo(f'  K>={k}:  {row["clustered"]:>5}/{row["eligible"]:<5} eligible accounts clustered  →  recall {recall}')
+    click.echo(f'\n=== Per category (K>={k_default}) ===')
+    for cat, row in sorted(by_category.items()):
+        recall = f"{row['recall']:.1%}" if row['recall'] is not None else 'n/a'
+        click.echo(f'  {cat:<15} {row["clustered"]:>5}/{row["eligible"]:<5}  {recall}')
+    click.echo(f'\nMetrics written to {output}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Phase 0 validation harness (scaffolded in 7bec943): loader + recall harness for the FiveThirtyEight/Clemson IRA troll-tweet corpus, isolated in `validation/ira.db` under platform tag `ira`
- First full run + calibration results in `validation/RESULTS.md`
- Fixes a cross-platform `cluster_id` collision in production code, found by the harness

## Headline results (unchanged production analyzer, default config)
| Window | K≥3 recall |
|---|---|
| Charlottesville week (Aug 2017, densest) | 99.5% |
| Pre-election week (Oct 2016) | 100% |
| Median-density day (Sep 2015) | 97.4% |
| Sparse tail week (Jan 2018) | 85.7% |

With-retweets numbers match without-retweets — recall doesn't lean on verbatim-copy clustering. NonEnglish accounts cluster at 96–100% (the TF-IDF tokenizer concern resolves benignly via sync/URL/hashtag edges).

**Key calibration finding:** the 90s sync channel saturates (median sync_rate 1.0 even at ~53 posts/hr), so recall on a troll-only corpus is necessary but cheap — the negative-control FPR leg is the load-bearing test and is next on the roadmap.

## Bug fix
`cluster_id` was minted from `time_window_start` alone against a globally-unique column, so two platforms analyzing the same hour silently dropped the second platform's clusters. Now platform-prefixed; re-analysis cleanup queries by platform+window, so no migration needed. Verified by same-day re-runs under both `ira` and `ira_rt` tags.

## Test plan
- [x] Smoke test: `load_ira.py --limit-files 1` + `run_validation.py --auto-window`
- [x] Full 13-CSV load (2,843 accounts / 1.65M originals / 1.30M retweets)
- [x] Recall runs on 4 windows × 2 retweet modes
- [x] Collision fix verified: `ira` + `ira_rt` re-analysis of same window in shared DB, zero IntegrityErrors

🤖 Generated with [Claude Code](https://claude.com/claude-code)